### PR TITLE
feat: send SMS to trainee on lesson creation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,11 @@
             <version>1.18.34</version>
         </dependency>
         <dependency>
+            <groupId>com.twilio.sdk</groupId>
+            <artifactId>twilio</artifactId>
+            <version>10.6.7</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/src/main/java/org/redcode/bookanddriveservice/config/SmsConfig.java
+++ b/src/main/java/org/redcode/bookanddriveservice/config/SmsConfig.java
@@ -1,0 +1,37 @@
+package org.redcode.bookanddriveservice.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "twilio")
+public class SmsConfig {
+
+    private String accountSid;
+    private String authToken;
+    private String fromNumber;
+
+    public String getAccountSid() {
+        return accountSid;
+    }
+
+    public void setAccountSid(String accountSid) {
+        this.accountSid = accountSid;
+    }
+
+    public String getAuthToken() {
+        return authToken;
+    }
+
+    public void setAuthToken(String authToken) {
+        this.authToken = authToken;
+    }
+
+    public String getFromNumber() {
+        return fromNumber;
+    }
+
+    public void setFromNumber(String fromNumber) {
+        this.fromNumber = fromNumber;
+    }
+}

--- a/src/main/java/org/redcode/bookanddriveservice/lessons/service/LessonsService.java
+++ b/src/main/java/org/redcode/bookanddriveservice/lessons/service/LessonsService.java
@@ -3,6 +3,7 @@ package org.redcode.bookanddriveservice.lessons.service;
 import static org.redcode.bookanddriveservice.exceptions.ResourceNotFoundException.RESOURECE_NOT_FOUND;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,7 @@ import org.redcode.bookanddriveservice.lessons.model.LessonEntity;
 import org.redcode.bookanddriveservice.lessons.repository.LessonCustomSearchRepository;
 import org.redcode.bookanddriveservice.lessons.repository.LessonSearchCriteria;
 import org.redcode.bookanddriveservice.lessons.repository.LessonsRepository;
+import org.redcode.bookanddriveservice.notifications.sms.SmsService;
 import org.redcode.bookanddriveservice.page.PageResponse;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -25,10 +27,13 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class LessonsService {
 
+    private static final DateTimeFormatter SMS_DATE_FORMATTER = DateTimeFormatter.ofPattern("dd.MM.yyyy 'at' HH:mm");
     public static final String DUPLICATE_KEY_VALUE_VIOLATES_UNIQUE_CONSTRAINT = "duplicate key value violates unique constraint";
+
     private final LessonsRepository lessonsRepository;
     private final LessonCustomSearchRepository lessonCustomRepository;
     private final InstructorsService instructorsService;
+    private final SmsService smsService;
 
     public Lesson create(Lesson lesson) {
         LocalDateTime startTime = lesson.getStartTime();
@@ -48,7 +53,23 @@ public class LessonsService {
             }
         }
 
-        return Lesson.from(lessonEntity);
+        Lesson saved = Lesson.from(lessonEntity);
+        sendLessonConfirmationSms(saved);
+        return saved;
+    }
+
+    private void sendLessonConfirmationSms(Lesson lesson) {
+        String phoneNumber = lesson.getTrainee().getPhoneNumber();
+        String traineeName = lesson.getTrainee().getName();
+        String formattedDate = lesson.getStartTime().format(SMS_DATE_FORMATTER);
+        String message = String.format(
+            "Hi %s, your driving lesson is scheduled for %s. See you there!", traineeName, formattedDate
+        );
+        try {
+            smsService.send(phoneNumber, message);
+        } catch (Exception e) {
+            log.error("Failed to send SMS notification to trainee {} ({}): {}", traineeName, phoneNumber, e.getMessage(), e);
+        }
     }
 
     public PageResponse<Lesson> findByCriteria(LessonSearchCriteria criteria, PageRequest pageRequest) {

--- a/src/main/java/org/redcode/bookanddriveservice/notifications/sms/SmsService.java
+++ b/src/main/java/org/redcode/bookanddriveservice/notifications/sms/SmsService.java
@@ -1,0 +1,6 @@
+package org.redcode.bookanddriveservice.notifications.sms;
+
+public interface SmsService {
+
+    void send(String to, String message);
+}

--- a/src/main/java/org/redcode/bookanddriveservice/notifications/sms/TwilioSmsService.java
+++ b/src/main/java/org/redcode/bookanddriveservice/notifications/sms/TwilioSmsService.java
@@ -1,0 +1,30 @@
+package org.redcode.bookanddriveservice.notifications.sms;
+
+import com.twilio.Twilio;
+import com.twilio.rest.api.v2010.account.Message;
+import com.twilio.type.PhoneNumber;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redcode.bookanddriveservice.config.SmsConfig;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TwilioSmsService implements SmsService {
+
+    private final SmsConfig smsConfig;
+
+    @PostConstruct
+    void init() {
+        Twilio.init(smsConfig.getAccountSid(), smsConfig.getAuthToken());
+    }
+
+    @Override
+    public void send(String to, String message) {
+        Message.creator(new PhoneNumber(to), new PhoneNumber(smsConfig.getFromNumber()), message)
+            .create();
+        log.info("SMS sent to {}", to);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,3 +41,8 @@ logging:
 app:
   cors:
     allowed-origins: ${APP_CORS_ALLOWED_ORIGINS:http://localhost:3000}
+
+twilio:
+  account-sid: ${TWILIO_ACCOUNT_SID}
+  auth-token: ${TWILIO_AUTH_TOKEN}
+  from-number: ${TWILIO_FROM_NUMBER}

--- a/src/test/java/org/redcode/bookanddriveservice/lessons/integrationtests/ITLessonsControllerTest.java
+++ b/src/test/java/org/redcode/bookanddriveservice/lessons/integrationtests/ITLessonsControllerTest.java
@@ -23,8 +23,10 @@ import org.redcode.bookanddriveservice.lessons.repository.LessonsRepository;
 import org.redcode.bookanddriveservice.page.PageResponse;
 import org.redcode.bookanddriveservice.trainees.model.TraineeEntity;
 import org.redcode.bookanddriveservice.trainees.repository.TraineesRepository;
+import org.redcode.bookanddriveservice.notifications.sms.SmsService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.core.ParameterizedTypeReference;
@@ -49,6 +51,9 @@ class ITLessonsControllerTest {
     @Container
     @ServiceConnection
     static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16");
+
+    @MockBean
+    SmsService smsService;
 
     @Autowired
     TestRestTemplate restTemplate;

--- a/src/test/java/org/redcode/bookanddriveservice/lessons/service/LessonsServiceTest.java
+++ b/src/test/java/org/redcode/bookanddriveservice/lessons/service/LessonsServiceTest.java
@@ -5,6 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.redcode.bookanddriveservice.lessons.utils.LessonsDataGenerator.generateInvalidLesson;
@@ -29,6 +33,7 @@ import org.redcode.bookanddriveservice.lessons.model.LessonEntity;
 import org.redcode.bookanddriveservice.lessons.repository.LessonCustomSearchRepository;
 import org.redcode.bookanddriveservice.lessons.repository.LessonSearchCriteria;
 import org.redcode.bookanddriveservice.lessons.repository.LessonsRepository;
+import org.redcode.bookanddriveservice.notifications.sms.SmsService;
 import org.redcode.bookanddriveservice.page.PageResponse;
 import org.springframework.data.domain.PageRequest;
 
@@ -42,6 +47,9 @@ class LessonsServiceTest {
 
     @Mock
     private org.redcode.bookanddriveservice.instructors.service.InstructorsService instructorsService;
+
+    @Mock
+    private SmsService smsService;
 
     @InjectMocks
     private LessonsService lessonsService;
@@ -63,6 +71,25 @@ class LessonsServiceTest {
         Lesson result = lessonsService.create(lesson);
 
         // Assert
+        assertNotNull(result);
+        assertEquals(lesson.getStartTime(), result.getStartTime());
+        assertEquals(lesson.getEndTime(), result.getEndTime());
+        verify(smsService, times(1)).send(anyString(), anyString());
+    }
+
+    @Test
+    void testCreate_shouldReturnLessonEvenWhenSmsFails() {
+        // Arrange
+        Lesson lesson = generateLesson();
+        LessonEntity lessonEntity = LessonEntity.from(lesson);
+
+        when(lessonsRepository.save(any(LessonEntity.class))).thenReturn(lessonEntity);
+        doThrow(new RuntimeException("Twilio unavailable")).when(smsService).send(anyString(), anyString());
+
+        // Act
+        Lesson result = lessonsService.create(lesson);
+
+        // Assert — lesson is returned despite SMS failure
         assertNotNull(result);
         assertEquals(lesson.getStartTime(), result.getStartTime());
         assertEquals(lesson.getEndTime(), result.getEndTime());

--- a/src/test/resources/application-integration-test.properties
+++ b/src/test/resources/application-integration-test.properties
@@ -1,1 +1,4 @@
 spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration
+twilio.account-sid=test-account-sid
+twilio.auth-token=test-auth-token
+twilio.from-number=+15005550006


### PR DESCRIPTION
## What changed
- Added Twilio Java SDK dependency
- New `notifications/sms/SmsService` interface and `TwilioSmsService` implementation
- New `SmsConfig` reads Twilio credentials from env vars: `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_FROM_NUMBER`
- `LessonsService.create()` now sends an SMS to the trainee after a successful save
- SMS failure is caught and logged at ERROR level — lesson creation is not blocked

## Why
- Trainees need to be notified about their scheduled lesson immediately after it is booked

## How to test
1. Set env vars: `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_FROM_NUMBER` (Twilio trial account)
2. Start the app and create a lesson via `POST /api/lessons`
3. Verify the trainee receives an SMS: `"Hi {name}, your driving lesson is scheduled for {date} at {HH:mm}. See you there!"`
4. To test failure handling: temporarily set an invalid auth token — lesson should still be created, error logged

## Checklist
- [x] Tests pass locally (`./mvnw verify`) — integration tests pass; 16 pre-existing unit `*ControllerTest` failures are on `main` and unrelated to this change
- [x] No `System.out.println` or debug code
- [x] Lint passes
- [ ] ROADMAP.md updated if this closes a task