### PR TITLE
feat: lesson scheduled email notification with ICS attachment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,11 @@
             <artifactId>spring-boot-starter-mail</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.resend</groupId>
+            <artifactId>resend-java</artifactId>
+            <version>3.1.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>

--- a/src/main/java/org/redcode/bookanddriveservice/lessons/service/LessonsService.java
+++ b/src/main/java/org/redcode/bookanddriveservice/lessons/service/LessonsService.java
@@ -16,6 +16,7 @@ import org.redcode.bookanddriveservice.lessons.model.LessonEntity;
 import org.redcode.bookanddriveservice.lessons.repository.LessonCustomSearchRepository;
 import org.redcode.bookanddriveservice.lessons.repository.LessonSearchCriteria;
 import org.redcode.bookanddriveservice.lessons.repository.LessonsRepository;
+import org.redcode.bookanddriveservice.notifications.service.LessonNotificationService;
 import org.redcode.bookanddriveservice.page.PageResponse;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -29,6 +30,7 @@ public class LessonsService {
     private final LessonsRepository lessonsRepository;
     private final LessonCustomSearchRepository lessonCustomRepository;
     private final InstructorsService instructorsService;
+    private final LessonNotificationService lessonNotificationService;
 
     public Lesson create(Lesson lesson) {
         LocalDateTime startTime = lesson.getStartTime();
@@ -48,7 +50,14 @@ public class LessonsService {
             }
         }
 
-        return Lesson.from(lessonEntity);
+        Lesson created = Lesson.from(lessonEntity);
+        try {
+            lessonNotificationService.sendLessonScheduledEmail(created, created.getTrainee());
+        } catch (Exception e) {
+            log.error("Failed to send lesson scheduled email [lessonId={}, traineeId={}]: {}",
+                created.getId(), created.getTrainee().getId(), e.getMessage());
+        }
+        return created;
     }
 
     public PageResponse<Lesson> findByCriteria(LessonSearchCriteria criteria, PageRequest pageRequest) {

--- a/src/main/java/org/redcode/bookanddriveservice/notifications/config/ResendConfig.java
+++ b/src/main/java/org/redcode/bookanddriveservice/notifications/config/ResendConfig.java
@@ -1,0 +1,18 @@
+package org.redcode.bookanddriveservice.notifications.config;
+
+import com.resend.Resend;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ResendConfig {
+
+    @Value("${resend.api-key}")
+    private String apiKey;
+
+    @Bean
+    public Resend resend() {
+        return new Resend(apiKey);
+    }
+}

--- a/src/main/java/org/redcode/bookanddriveservice/notifications/service/IcsGeneratorService.java
+++ b/src/main/java/org/redcode/bookanddriveservice/notifications/service/IcsGeneratorService.java
@@ -1,0 +1,35 @@
+package org.redcode.bookanddriveservice.notifications.service;
+
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+import java.util.UUID;
+import org.redcode.bookanddriveservice.instructors.domain.Instructor;
+import org.redcode.bookanddriveservice.lessons.domain.Lesson;
+import org.springframework.stereotype.Service;
+
+@Service
+public class IcsGeneratorService {
+
+    private static final DateTimeFormatter ICS_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss");
+
+    public String generateBase64(Lesson lesson, Instructor instructor) {
+        String ics = buildIcs(lesson, instructor);
+        return Base64.getEncoder().encodeToString(ics.getBytes());
+    }
+
+    private String buildIcs(Lesson lesson, Instructor instructor) {
+        String instructorFullName = instructor.getName() + " " + instructor.getSurname();
+
+        return "BEGIN:VCALENDAR\r\n" +
+               "VERSION:2.0\r\n" +
+               "PRODID:-//DriveDesk//EN\r\n" +
+               "BEGIN:VEVENT\r\n" +
+               "UID:" + UUID.randomUUID() + "\r\n" +
+               "DTSTART:" + lesson.getStartTime().format(ICS_DATE_FORMAT) + "\r\n" +
+               "DTEND:" + lesson.getEndTime().format(ICS_DATE_FORMAT) + "\r\n" +
+               "SUMMARY:Driving Lesson - " + instructorFullName + "\r\n" +
+               "DESCRIPTION:Instructor: " + instructorFullName + "\r\n" +
+               "END:VEVENT\r\n" +
+               "END:VCALENDAR\r\n";
+    }
+}

--- a/src/main/java/org/redcode/bookanddriveservice/notifications/service/LessonNotificationService.java
+++ b/src/main/java/org/redcode/bookanddriveservice/notifications/service/LessonNotificationService.java
@@ -1,0 +1,87 @@
+package org.redcode.bookanddriveservice.notifications.service;
+
+import com.resend.Resend;
+import com.resend.core.exception.ResendException;
+import com.resend.services.emails.model.Attachment;
+import com.resend.services.emails.model.CreateEmailOptions;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redcode.bookanddriveservice.instructors.domain.Instructor;
+import org.redcode.bookanddriveservice.instructors.service.InstructorsService;
+import org.redcode.bookanddriveservice.lessons.domain.Lesson;
+import org.redcode.bookanddriveservice.trainees.domain.Trainee;
+import org.redcode.bookanddriveservice.trainees.service.TraineesService;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LessonNotificationService {
+
+    private static final String SENDER = "onboarding@resend.dev";
+    private static final DateTimeFormatter DISPLAY_DATE_FORMAT = DateTimeFormatter.ofPattern("EEEE, MMMM d yyyy");
+    private static final DateTimeFormatter DISPLAY_TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm");
+
+    private final Resend resend;
+    private final IcsGeneratorService icsGeneratorService;
+    private final InstructorsService instructorsService;
+    private final TraineesService traineesService;
+
+    public void sendLessonScheduledEmail(Lesson lesson, Trainee trainee) {
+        Instructor instructor = instructorsService.findById(lesson.getInstructor().getId());
+        Trainee fullTrainee = traineesService.findById(trainee.getId());
+
+        if (instructor == null || fullTrainee == null) {
+            log.warn("Cannot send lesson scheduled email: instructor or trainee not found [lessonId={}, traineeId={}]",
+                lesson.getId(), trainee.getId());
+            return;
+        }
+
+        String icsBase64 = icsGeneratorService.generateBase64(lesson, instructor);
+        String htmlBody = buildHtmlBody(lesson, instructor, fullTrainee);
+        String instructorFullName = instructor.getName() + " " + instructor.getSurname();
+
+        Attachment icsAttachment = Attachment.builder()
+            .fileName("lesson.ics")
+            .content(icsBase64)
+            .build();
+
+        CreateEmailOptions request = CreateEmailOptions.builder()
+            .from(SENDER)
+            .to(fullTrainee.getEmail())
+            .subject("Driving Lesson Scheduled – " + lesson.getStartTime().format(DISPLAY_DATE_FORMAT))
+            .html(htmlBody)
+            .attachments(List.of(icsAttachment))
+            .build();
+
+        try {
+            resend.emails().send(request);
+            log.info("Lesson scheduled email sent [lessonId={}, traineeId={}, instructor={}]",
+                lesson.getId(), fullTrainee.getId(), instructorFullName);
+        } catch (ResendException e) {
+            log.error("Failed to send lesson scheduled email [lessonId={}, traineeId={}]: {}",
+                lesson.getId(), fullTrainee.getId(), e.getMessage());
+        }
+    }
+
+    private String buildHtmlBody(Lesson lesson, Instructor instructor, Trainee trainee) {
+        String instructorFullName = instructor.getName() + " " + instructor.getSurname();
+        String date = lesson.getStartTime().format(DISPLAY_DATE_FORMAT);
+        String startTime = lesson.getStartTime().format(DISPLAY_TIME_FORMAT);
+        String endTime = lesson.getEndTime().format(DISPLAY_TIME_FORMAT);
+
+        return "<html><body>" +
+               "<h2>Driving Lesson Scheduled</h2>" +
+               "<p>Hi " + trainee.getName() + ",</p>" +
+               "<p>Your driving lesson has been scheduled. Here are the details:</p>" +
+               "<ul>" +
+               "<li><strong>Date:</strong> " + date + "</li>" +
+               "<li><strong>Time:</strong> " + startTime + " – " + endTime + "</li>" +
+               "<li><strong>Instructor:</strong> " + instructorFullName + "</li>" +
+               "</ul>" +
+               "<p>A calendar invite is attached. See you there!</p>" +
+               "</body></html>";
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,3 +41,6 @@ logging:
 app:
   cors:
     allowed-origins: ${APP_CORS_ALLOWED_ORIGINS:http://localhost:3000}
+
+resend:
+  api-key: ${RESEND_API_KEY:}

--- a/src/test/java/org/redcode/bookanddriveservice/lessons/service/LessonsServiceTest.java
+++ b/src/test/java/org/redcode/bookanddriveservice/lessons/service/LessonsServiceTest.java
@@ -29,6 +29,7 @@ import org.redcode.bookanddriveservice.lessons.model.LessonEntity;
 import org.redcode.bookanddriveservice.lessons.repository.LessonCustomSearchRepository;
 import org.redcode.bookanddriveservice.lessons.repository.LessonSearchCriteria;
 import org.redcode.bookanddriveservice.lessons.repository.LessonsRepository;
+import org.redcode.bookanddriveservice.notifications.service.LessonNotificationService;
 import org.redcode.bookanddriveservice.page.PageResponse;
 import org.springframework.data.domain.PageRequest;
 
@@ -42,6 +43,9 @@ class LessonsServiceTest {
 
     @Mock
     private org.redcode.bookanddriveservice.instructors.service.InstructorsService instructorsService;
+
+    @Mock
+    private LessonNotificationService lessonNotificationService;
 
     @InjectMocks
     private LessonsService lessonsService;


### PR DESCRIPTION
## What

Sends an email to the trainee when a driving lesson is scheduled, with an `.ics` calendar invite attached.

## Changes

- **`pom.xml`** — adds `resend-java:3.1.0` dependency
- **`application.yml`** — adds `resend.api-key` loaded from `RESEND_API_KEY` env variable
- **`notifications/config/ResendConfig`** — `@Configuration` bean initialising the `Resend` client
- **`notifications/service/IcsGeneratorService`** — builds a VCALENDAR string (DTSTART, DTEND, SUMMARY, DESCRIPTION) and returns it Base64-encoded for attachment
- **`notifications/service/LessonNotificationService`** — fetches full instructor and trainee by ID, builds an HTML email body, attaches `lesson.ics`, and sends via Resend from `onboarding@resend.dev` (sandbox sender)
- **`lessons/service/LessonsService`** — calls `sendLessonScheduledEmail()` after successful persist, wrapped in `try/catch` so email failure never rolls back the lesson transaction
- **`LessonsServiceTest`** — adds `@Mock LessonNotificationService` to keep existing unit tests passing

## Behaviour notes

- Email is **best-effort**: failures are logged at ERROR level with lessonId + traineeId but never rethrow
- **Sandbox mode**: Resend delivers only to your own verified email until a sender domain is confirmed
- No UI changes. No entity changes.

## Test plan

- [x] `./mvnw verify` — 84 tests, 0 failures
- [ ] Set `RESEND_API_KEY` env var and create a lesson via `POST /api/lessons` — verify email arrives with `.ics` attachment

🤖 Generated with [Claude Code](https://claude.com/claude-code)